### PR TITLE
remove faulty import of partial

### DIFF
--- a/popjym/wrappers.py
+++ b/popjym/wrappers.py
@@ -1,6 +1,7 @@
 import jax
 import jax.numpy as jnp
 from flax import struct
+from functools import partial
 from gymnax.wrappers.purerl import (
     GymnaxWrapper,
     Optional,
@@ -8,7 +9,6 @@ from gymnax.wrappers.purerl import (
     Union,
     chex,
     environment,
-    partial,
     spaces,
 )
 


### PR DESCRIPTION
The current version fails with Error: 
`ImportError: cannot import name 'partial' from 'gymnax.wrappers.purerl' `

This PR fixes this issue.